### PR TITLE
Ver 2.8:Cambio nombre ratón a M20B10a-Mejorado escaneo, uso de los grid

### DIFF
--- a/Practica02/MouseRun/src/mouserun/mouse/M20B10a.java
+++ b/Practica02/MouseRun/src/mouserun/mouse/M20B10a.java
@@ -15,7 +15,7 @@ import mouserun.game.Cheese;
  * @author Cristóbal José Carmona (ccarmona@ujaen.es) y Ángel Miguel García Vico (agvico@ujaen.es)
  * @author Ana Montijano Zaragoza y Alejandro Molero Gómez
  */
-public class MXXA04 extends Mouse {
+public class M20B10a extends Mouse {
 
     /**
      * Variable para almacenar la ultima celda visitada
@@ -43,8 +43,8 @@ public class MXXA04 extends Mouse {
     /**
      * Constructor (Puedes modificar el nombre a tu gusto).
      */
-    public MXXA04() {
-        super("MXXA04");
+    public M20B10a() {
+        super("M20B10a");
         celdasVisitadas = new HashMap<>();
         pilaMovimientos = new Stack<>();
     }
@@ -118,6 +118,7 @@ public class MXXA04 extends Mouse {
      * @return movimiento de regreso del raton
      */
     int posRegreso(Grid celdaActual){   //Falta un caso por tener en cuenta
+        
 //        if(pilaMovimientos.peek().equals(casillaActual))
 //            return -1;  //Es la misma casilla, fallo grave
         

--- a/Practica02/MouseRun/src/mouserun/mouse/TestMouse.java
+++ b/Practica02/MouseRun/src/mouserun/mouse/TestMouse.java
@@ -1,102 +1,102 @@
-//package mouserun.mouse;		
-//import mouserun.game.*;		
-//import java.util.*;			
-//
-//public class TestMouse
-//	extends Mouse				
-//{
-//
-//	private Grid lastGrid;
-//
-//	public TestMouse()
-//	{
-//		super("Test");		
-//	}
-//	
-//	public int move(Grid currentGrid, Cheese cheese)
-//	{
-//		Random random = new Random();
-//		ArrayList<Integer> possibleMoves = new ArrayList<Integer>();
-//		if (currentGrid.canGoUp()) possibleMoves.add(Mouse.UP);
-//		if (currentGrid.canGoDown()) possibleMoves.add(Mouse.DOWN);
-//		if (currentGrid.canGoLeft()) possibleMoves.add(Mouse.LEFT);
-//		if (currentGrid.canGoRight()) possibleMoves.add(Mouse.RIGHT);
-//		possibleMoves.add(Mouse.BOMB);
-//				
-//		if (possibleMoves.size() == 1)
-//		{
-//			lastGrid = currentGrid;
-//			return possibleMoves.get(0);
-//		}
-//		else
-//		{
-//			if (!testGrid(Mouse.UP, currentGrid)) possibleMoves.remove((Integer)Mouse.UP);
-//			if (!testGrid(Mouse.DOWN, currentGrid)) possibleMoves.remove((Integer)Mouse.DOWN);
-//			if (!testGrid(Mouse.LEFT, currentGrid)) possibleMoves.remove((Integer)Mouse.LEFT);
-//			if (!testGrid(Mouse.RIGHT, currentGrid)) possibleMoves.remove((Integer)Mouse.RIGHT);
-//		
-//			if (possibleMoves.size() == 0)
-//			{
-//				if (currentGrid.canGoUp()) possibleMoves.add(Mouse.UP);
-//				if (currentGrid.canGoDown()) possibleMoves.add(Mouse.DOWN);
-//				if (currentGrid.canGoLeft()) possibleMoves.add(Mouse.LEFT);
-//				if (currentGrid.canGoRight()) possibleMoves.add(Mouse.RIGHT);
-//				possibleMoves.add(Mouse.BOMB);
-//				
-//				lastGrid = currentGrid;
-//				return possibleMoves.get(random.nextInt(possibleMoves.size()));
-//			}
-//			else
-//			{
-//				lastGrid = currentGrid;
-//				return possibleMoves.get(random.nextInt(possibleMoves.size()));
-//			}
-//		}
-//		
-//	}
-//	
-//	public void newCheese()
-//	{
-//	
-//	}
-//	
-//	public void respawned()
-//	{
-//	
-//	}
-//	
-//	private boolean testGrid(int direction, Grid currentGrid)
-//	{
-//		if (lastGrid == null)
-//		{
-//			return true;
-//		}	
-//	
-//		int x = currentGrid.getX();
-//		int y = currentGrid.getY();
-//		
-//		switch (direction)
-//		{
-//			case Mouse.UP: 
-//				y += 1;
-//				break;
-//				
-//			case Mouse.DOWN:
-//				y -= 1;
-//				break;
-//				
-//			case Mouse.LEFT:
-//				x -= 1;
-//				break;
-//				
-//			case Mouse.RIGHT:
-//				x += 1;
-//				break;
-//		}
-//		
-//		return !(lastGrid.getX() == x && lastGrid.getY() == y);
-//		
-//	}
-//	
-//	
-//}
+package mouserun.mouse;		
+import mouserun.game.*;		
+import java.util.*;			
+
+public class TestMouse
+	extends Mouse				
+{
+
+	private Grid lastGrid;
+
+	public TestMouse()
+	{
+		super("Test");		
+	}
+	
+	public int move(Grid currentGrid, Cheese cheese)
+	{
+		Random random = new Random();
+		ArrayList<Integer> possibleMoves = new ArrayList<Integer>();
+		if (currentGrid.canGoUp()) possibleMoves.add(Mouse.UP);
+		if (currentGrid.canGoDown()) possibleMoves.add(Mouse.DOWN);
+		if (currentGrid.canGoLeft()) possibleMoves.add(Mouse.LEFT);
+		if (currentGrid.canGoRight()) possibleMoves.add(Mouse.RIGHT);
+		possibleMoves.add(Mouse.BOMB);
+				
+		if (possibleMoves.size() == 1)
+		{
+			lastGrid = currentGrid;
+			return possibleMoves.get(0);
+		}
+		else
+		{
+			if (!testGrid(Mouse.UP, currentGrid)) possibleMoves.remove((Integer)Mouse.UP);
+			if (!testGrid(Mouse.DOWN, currentGrid)) possibleMoves.remove((Integer)Mouse.DOWN);
+			if (!testGrid(Mouse.LEFT, currentGrid)) possibleMoves.remove((Integer)Mouse.LEFT);
+			if (!testGrid(Mouse.RIGHT, currentGrid)) possibleMoves.remove((Integer)Mouse.RIGHT);
+		
+			if (possibleMoves.size() == 0)
+			{
+				if (currentGrid.canGoUp()) possibleMoves.add(Mouse.UP);
+				if (currentGrid.canGoDown()) possibleMoves.add(Mouse.DOWN);
+				if (currentGrid.canGoLeft()) possibleMoves.add(Mouse.LEFT);
+				if (currentGrid.canGoRight()) possibleMoves.add(Mouse.RIGHT);
+				possibleMoves.add(Mouse.BOMB);
+				
+				lastGrid = currentGrid;
+				return possibleMoves.get(random.nextInt(possibleMoves.size()));
+			}
+			else
+			{
+				lastGrid = currentGrid;
+				return possibleMoves.get(random.nextInt(possibleMoves.size()));
+			}
+		}
+		
+	}
+	
+	public void newCheese()
+	{
+	
+	}
+	
+	public void respawned()
+	{
+	
+	}
+	
+	private boolean testGrid(int direction, Grid currentGrid)
+	{
+		if (lastGrid == null)
+		{
+			return true;
+		}	
+	
+		int x = currentGrid.getX();
+		int y = currentGrid.getY();
+		
+		switch (direction)
+		{
+			case Mouse.UP: 
+				y += 1;
+				break;
+				
+			case Mouse.DOWN:
+				y -= 1;
+				break;
+				
+			case Mouse.LEFT:
+				x -= 1;
+				break;
+				
+			case Mouse.RIGHT:
+				x += 1;
+				break;
+		}
+		
+		return !(lastGrid.getX() == x && lastGrid.getY() == y);
+		
+	}
+	
+	
+}


### PR DESCRIPTION
Comentarios del M20B10a::posRegreso()
El ratón anterior fallaba al recorrer las mismas ultimas dos casillas.
Alternativa al switch creada.