### PR TITLE
Ver 4.1.2: Raton M20B10c función búsqueda greed, comenzando

### DIFF
--- a/Practica02/MouseRun/src/mouserun/mouse/M20B10c.java
+++ b/Practica02/MouseRun/src/mouserun/mouse/M20B10c.java
@@ -2,7 +2,6 @@ package mouserun.mouse;
 
 import java.util.TreeMap;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.Stack;


### PR DESCRIPTION
Arreglando fallo planificarProfundidad():
La búsqueda en recursividad falla a la hora de verificar las casillas visitadas
no funciona con la pila, cambiar a la hora de eliminar elementos