### PR TITLE
Ver 8.2.1: vector de nodos implementado, no funciona

### DIFF
--- a/Practica04/Conecta4/src/conecta4/IAPlayer.java
+++ b/Practica04/Conecta4/src/conecta4/IAPlayer.java
@@ -461,7 +461,6 @@ public class IAPlayer extends Player {
         
         /**
          * Muestra el numero de filas que tiene la matriz del nodo
-         * 
          * @return devuelve el número de filas
          */
         public int getFilaNodo(){


### PR DESCRIPTION
Necesidad de arreglar el minimax para adaptarlo a la heurística.
He contemplado 4 posibles heurísticas para calcular el valor.