### PR TITLE
Ver 8.2.2: vector de nodos implementado, no funciona

### DIFF
--- a/Practica04/Conecta4/src/conecta4/IAPlayer.java
+++ b/Practica04/Conecta4/src/conecta4/IAPlayer.java
@@ -18,6 +18,7 @@ import java.util.TreeSet;
 public class IAPlayer extends Player {  
     int limite = 3;
     
+    
     /**
      *
      * @param tablero Representación del tablero de juego


### PR DESCRIPTION
Necesidad de arreglar el minimax para adaptarlo a la heurística.
He contemplado 4 posibles heurísticas para calcular el valor.